### PR TITLE
Fix textColor not working

### DIFF
--- a/PTPPlaceholderTextView-Demo/ViewController.swift
+++ b/PTPPlaceholderTextView-Demo/ViewController.swift
@@ -12,6 +12,11 @@ import PTPPlaceholderTextView
 class ViewController: UIViewController {
   
   @IBOutlet weak var textview: PTPPlaceholderTextView!
+  
+  override func viewDidLoad() {
+    self.textview.textColor = UIColor.redColor()
+  }
+  
   @IBAction func dismissKeyboard(sender: UIBarButtonItem) {
     textview.resignFirstResponder()
   }

--- a/PTPPlaceholderTextView.swift
+++ b/PTPPlaceholderTextView.swift
@@ -41,15 +41,8 @@ import UIKit
   
   // MARK: - Override properties
   override public var textColor: UIColor? {
-    get {
-      return self.isPlaceholderActive ? self.actualTextColor : super.textColor
-    }
-    set {
-      if self.isPlaceholderActive {
-        self.actualTextColor = textColor
-      } else {
-        super.textColor = newValue
-      }
+    didSet {
+      self.actualTextColor = self.textColor
     }
   }
   override public var attributedText: NSAttributedString? {

--- a/PTPPlaceholderTextView.xcodeproj/project.pbxproj
+++ b/PTPPlaceholderTextView.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		8A9374DB1C19EB6A000E6098 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8A9374DA1C19EB6A000E6098 /* Assets.xcassets */; };
 		8A9374DE1C19EB6A000E6098 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A9374DC1C19EB6A000E6098 /* LaunchScreen.storyboard */; };
 		8A9374E51C19EC86000E6098 /* PTPPlaceholderTextView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0614171C19D7BB00C731E4 /* PTPPlaceholderTextView.framework */; };
+		A06AD8721C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06AD8711C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.swift */; };
+		A06AD8741C7ECA6D00A94D6A /* PTPPlaceholderTextView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0614171C19D7BB00C731E4 /* PTPPlaceholderTextView.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -24,6 +26,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8A0614161C19D7BB00C731E4;
 			remoteInfo = PTPPlaceholderTextView;
+		};
+		A06AD8751C7ECA6D00A94D6A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8A06140E1C19D7BB00C731E4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A0614161C19D7BB00C731E4;
+			remoteInfo = PTPPlaceholderTextView;
+		};
+		A06AD87A1C7ECB0F00A94D6A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8A06140E1C19D7BB00C731E4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A9374D01C19EB6A000E6098;
+			remoteInfo = "PTPPlaceholderTextView-Demo";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -39,6 +55,9 @@
 		8A9374DA1C19EB6A000E6098 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8A9374DD1C19EB6A000E6098 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8A9374DF1C19EB6A000E6098 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A06AD86F1C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PTPPlaceholderTextViewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A06AD8711C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTPPlaceholderTextViewTests.swift; sourceTree = "<group>"; };
+		A06AD8731C7ECA6D00A94D6A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +76,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A06AD86C1C7ECA6D00A94D6A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A06AD8741C7ECA6D00A94D6A /* PTPPlaceholderTextView.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -65,6 +92,7 @@
 			children = (
 				8A0614191C19D7BC00C731E4 /* PTPPlaceholderTextView */,
 				8A9374D21C19EB6A000E6098 /* PTPPlaceholderTextView-Demo */,
+				A06AD8701C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests */,
 				8A0614181C19D7BB00C731E4 /* Products */,
 			);
 			indentWidth = 2;
@@ -77,6 +105,7 @@
 			children = (
 				8A0614171C19D7BB00C731E4 /* PTPPlaceholderTextView.framework */,
 				8A9374D11C19EB6A000E6098 /* PTPPlaceholderTextView-Demo.app */,
+				A06AD86F1C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -102,6 +131,15 @@
 				8A9374DF1C19EB6A000E6098 /* Info.plist */,
 			);
 			path = "PTPPlaceholderTextView-Demo";
+			sourceTree = "<group>";
+		};
+		A06AD8701C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests */ = {
+			isa = PBXGroup;
+			children = (
+				A06AD8711C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.swift */,
+				A06AD8731C7ECA6D00A94D6A /* Info.plist */,
+			);
+			path = PTPPlaceholderTextViewTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -154,6 +192,25 @@
 			productReference = 8A9374D11C19EB6A000E6098 /* PTPPlaceholderTextView-Demo.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A06AD86E1C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A06AD8791C7ECA6D00A94D6A /* Build configuration list for PBXNativeTarget "PTPPlaceholderTextViewTests" */;
+			buildPhases = (
+				A06AD86B1C7ECA6D00A94D6A /* Sources */,
+				A06AD86C1C7ECA6D00A94D6A /* Frameworks */,
+				A06AD86D1C7ECA6D00A94D6A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A06AD8761C7ECA6D00A94D6A /* PBXTargetDependency */,
+				A06AD87B1C7ECB0F00A94D6A /* PBXTargetDependency */,
+			);
+			name = PTPPlaceholderTextViewTests;
+			productName = PTPPlaceholderTextViewTests;
+			productReference = A06AD86F1C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -169,6 +226,9 @@
 					};
 					8A9374D01C19EB6A000E6098 = {
 						CreatedOnToolsVersion = 7.2;
+					};
+					A06AD86E1C7ECA6D00A94D6A = {
+						CreatedOnToolsVersion = 7.2.1;
 					};
 				};
 			};
@@ -187,6 +247,7 @@
 			targets = (
 				8A0614161C19D7BB00C731E4 /* PTPPlaceholderTextView */,
 				8A9374D01C19EB6A000E6098 /* PTPPlaceholderTextView-Demo */,
+				A06AD86E1C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests */,
 			);
 		};
 /* End PBXProject section */
@@ -206,6 +267,13 @@
 				8A9374DE1C19EB6A000E6098 /* LaunchScreen.storyboard in Resources */,
 				8A9374DB1C19EB6A000E6098 /* Assets.xcassets in Resources */,
 				8A9374D91C19EB6A000E6098 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A06AD86D1C7ECA6D00A94D6A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -229,6 +297,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A06AD86B1C7ECA6D00A94D6A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A06AD8721C7ECA6D00A94D6A /* PTPPlaceholderTextViewTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -236,6 +312,16 @@
 			isa = PBXTargetDependency;
 			target = 8A0614161C19D7BB00C731E4 /* PTPPlaceholderTextView */;
 			targetProxy = 8A9374E31C19EC83000E6098 /* PBXContainerItemProxy */;
+		};
+		A06AD8761C7ECA6D00A94D6A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A0614161C19D7BB00C731E4 /* PTPPlaceholderTextView */;
+			targetProxy = A06AD8751C7ECA6D00A94D6A /* PBXContainerItemProxy */;
+		};
+		A06AD87B1C7ECB0F00A94D6A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A9374D01C19EB6A000E6098 /* PTPPlaceholderTextView-Demo */;
+			targetProxy = A06AD87A1C7ECB0F00A94D6A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -407,6 +493,26 @@
 			};
 			name = Release;
 		};
+		A06AD8771C7ECA6D00A94D6A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = PTPPlaceholderTextViewTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sarunw.PTPPlaceholderTextViewTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		A06AD8781C7ECA6D00A94D6A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = PTPPlaceholderTextViewTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sarunw.PTPPlaceholderTextViewTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -433,6 +539,15 @@
 			buildConfigurations = (
 				8A9374E11C19EB6A000E6098 /* Debug */,
 				8A9374E21C19EB6A000E6098 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A06AD8791C7ECA6D00A94D6A /* Build configuration list for PBXNativeTarget "PTPPlaceholderTextViewTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A06AD8771C7ECA6D00A94D6A /* Debug */,
+				A06AD8781C7ECA6D00A94D6A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/PTPPlaceholderTextView.xcodeproj/xcshareddata/xcschemes/PTPPlaceholderTextView.xcscheme
+++ b/PTPPlaceholderTextView.xcodeproj/xcshareddata/xcschemes/PTPPlaceholderTextView.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A06AD86E1C7ECA6D00A94D6A"
+               BuildableName = "PTPPlaceholderTextViewTests.xctest"
+               BlueprintName = "PTPPlaceholderTextViewTests"
+               ReferencedContainer = "container:PTPPlaceholderTextView.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8A0614161C19D7BB00C731E4"
+            BuildableName = "PTPPlaceholderTextView.framework"
+            BlueprintName = "PTPPlaceholderTextView"
+            ReferencedContainer = "container:PTPPlaceholderTextView.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/PTPPlaceholderTextViewTests/Info.plist
+++ b/PTPPlaceholderTextViewTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/PTPPlaceholderTextViewTests/PTPPlaceholderTextViewTests.swift
+++ b/PTPPlaceholderTextViewTests/PTPPlaceholderTextViewTests.swift
@@ -1,0 +1,32 @@
+//
+//  PTPPlaceholderTextViewTests.swift
+//  PTPPlaceholderTextViewTests
+//
+//  Created by Sarun Wongpatcharapakorn on 2/25/16.
+//  Copyright © 2016 Pitiphong Phongpattranont. All rights reserved.
+//
+
+import XCTest
+@testable import PTPPlaceholderTextView
+
+class PTPPlaceholderTextViewTests: XCTestCase {
+  
+    let textView = PTPPlaceholderTextView()
+  
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testTextColor() {
+      self.textView.textColor = UIColor.redColor()
+      
+      XCTAssertEqual(self.textView.textColor, UIColor.redColor())
+    }
+    
+}


### PR DESCRIPTION
You put unnecessary logic in setter/getter textColor (which cause setting textColor not work).

Every time you render placeholder/actual text you set `textColor` a new value, so your set/get logic can be ignore.

```
private func renderPlaceholderText() {
    // We don't render placeholder while this text view is the first responder.
    guard !self.isFirstResponder() else {
      return
    }

    // We need to set to rendering placeholder mode due to the implementation of UITextView,
    // which can cause `renderPlaceholderText` method to be called multiple times during placeholder text rendering
    isInRenderingPlaceholderProcess = true
    if isPlaceholderActive {
      super.text = self.placeholder
    }
    super.textColor = isPlaceholderActive ? self.placeholderColor : self.actualTextColor
    isInRenderingPlaceholderProcess = false
  }
```

```
 override public func becomeFirstResponder() -> Bool {
    let becomeResponder = super.becomeFirstResponder()
    // Disable the placeholder text when this text view becomes first responder.
    if becomeResponder && isPlaceholderActive {
      super.text = nil
      super.textColor = self.actualTextColor
      isPlaceholderActive = false
    }
    return becomeResponder
  }
```

The thing that you need based on the code is 
`super.textColor = isPlaceholderActive ? self.placeholderColor : self.actualTextColor` and `super.textColor = self.actualTextColor` 

which is `self.actualTextColor` and `self.placeholderColor`

so override version of `textColor` should be just

```
override public var textColor: UIColor? {
    didSet {
      self.actualTextColor = self.textColor
    }
  }
```

I also write a test for this case.
